### PR TITLE
Remove redis namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,8 @@ Available options:
 * `heartbeat_expires`: (override) time in seconds for process heardbeat to expire
 * `failure_threshold`: (override) Number of tries before tripping circuit breaker
 * `breaker_timeout`: (override) time in seconds to wait before switching breaker to half-open
+* `cache`: use the first-level cache, defaults to true. If set to false, will always call the
+  fallback, but if an error is raised, will use the last known good value.
 
 ```ruby
 Cachext.multi key_base, ids, options, &block

--- a/cachext.gemspec
+++ b/cachext.gemspec
@@ -15,17 +15,14 @@ Gem::Specification.new do |spec|
   spec.license       = "MIT"
 
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
-  spec.bindir        = "exe"
-  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "activesupport", "~> 4.2"
-  spec.add_dependency "redis"
-  spec.add_dependency "redis-namespace"
-  spec.add_dependency "redlock"
   spec.add_dependency "faraday"
+  spec.add_dependency "redis"
+  spec.add_dependency "redlock"
   spec.add_dependency "dalli"
 
+  spec.add_development_dependency "activesupport"
   spec.add_development_dependency "bundler", "~> 1.10"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec"

--- a/lib/cachext.rb
+++ b/lib/cachext.rb
@@ -1,5 +1,4 @@
 require "cachext/version"
-require "faraday/error"
 
 module Cachext
   autoload :Breaker, "cachext/breaker"
@@ -50,7 +49,12 @@ module Cachext
   end
 
   def self.configure &block
+    @config_block = block
     @config = Configuration.setup(&block)
     @client = Client.new @config
+  end
+
+  def self.forked!
+    configure(&@config_block)
   end
 end

--- a/lib/cachext/breaker.rb
+++ b/lib/cachext/breaker.rb
@@ -21,9 +21,9 @@ module Cachext
       end
 
       def increment_failure
-        redis.pipelined do
-          redis.set key_str(:last_failure), Time.now.to_f
-          redis.incr key_str(:monitor)
+        lock_redis.pipelined do
+          lock_redis.set key_str(:last_failure), Time.now.to_f
+          lock_redis.incr key_str(:monitor)
         end
       end
 
@@ -38,7 +38,7 @@ module Cachext
       end
 
       def reset!
-        redis.del key_str(:monitor),
+        lock_redis.del key_str(:monitor),
                   key_str(:health_check),
                   key_str(:last_failure)
       end
@@ -62,27 +62,27 @@ module Cachext
       end
 
       def monitor
-        redis.get(key_str(:monitor)).to_i
+        lock_redis.get(key_str(:monitor)).to_i
       end
 
       def last_failure
-        lf = redis.get key_str(:last_failure)
+        lf = lock_redis.get key_str(:last_failure)
         lf.nil? ? nil : lf.to_f
       end
 
       def health_check
-        redis.get(key_str(:health_check)).to_i
+        lock_redis.get(key_str(:health_check)).to_i
       end
 
       def increment_health_check
-        redis.incr key_str(:health_check)
+        lock_redis.incr key_str(:health_check)
       end
 
       def key_str(name)
-        "#{name}:#{key.raw.map(&:to_s).join(":")}"
+        "cachext:#{name}:#{key.raw.map(&:to_s).join(":")}"
       end
 
-      def redis
+      def lock_redis
         config.lock_redis
       end
     end

--- a/lib/cachext/client.rb
+++ b/lib/cachext/client.rb
@@ -50,7 +50,7 @@ module Cachext
     end
 
     def write key, fresh, options
-      key.write fresh, expires_in: options.expires_in
+      key.write fresh, expires_in: options.expires_in if options.cache?
     end
   end
 end

--- a/lib/cachext/configuration.rb
+++ b/lib/cachext/configuration.rb
@@ -1,6 +1,6 @@
 require "redlock"
-require "redis-namespace"
 require "thread"
+require "faraday/error"
 
 module Cachext
   class Configuration
@@ -59,7 +59,7 @@ module Cachext
     end
 
     def lock_redis
-      @lock_redis ||= Redis::Namespace.new :cachext, redis: redis
+      redis
     end
 
     def log_errors?
@@ -69,7 +69,7 @@ module Cachext
     def debug
       if block_given?
         if @debug
-          @mutex.synchronize do
+          @debug_mutex.synchronize do
             yield
           end
         end

--- a/lib/cachext/features/circuit_breaker.rb
+++ b/lib/cachext/features/circuit_breaker.rb
@@ -11,7 +11,9 @@ module Cachext
       def read key, options
         circuit = breaker.for(key)
         if circuit.open?
-          key.read_backup
+          val = key.read_backup
+          debug_log { { m: :circuit_open, key: key, msg: "Circuit breaker open, reading from backup", val: val.inspect } }
+          val
         else
           circuit.check_health
           super

--- a/lib/cachext/features/lock.rb
+++ b/lib/cachext/features/lock.rb
@@ -19,7 +19,7 @@ module Cachext
       end
 
       def call_block key, options, &block
-        with_heartbeat_extender key.digest, options.heartbeat_expires do
+        with_heartbeat_extender key.lock_key, options.heartbeat_expires do
           super
         end
       end
@@ -46,9 +46,9 @@ module Cachext
       def obtain_lock key, options
         start_time = Time.now
 
-        until lock_info ||= @config.lock_manager.lock(key.digest, (options.heartbeat_expires * 1000).ceil)
+        until lock_info ||= @config.lock_manager.lock(key.lock_key, (options.heartbeat_expires * 1000).ceil)
           if wait_for_lock(key, start_time) == :timeout
-            lock_info = @config.lock_manager.lock(key.digest, (options.heartbeat_expires * 1000).ceil)
+            lock_info = @config.lock_manager.lock(key.lock_key, (options.heartbeat_expires * 1000).ceil)
             raise TimeoutWaitingForLock unless lock_info
           end
         end

--- a/lib/cachext/key.rb
+++ b/lib/cachext/key.rb
@@ -19,8 +19,12 @@ module Cachext
       [:backup_cache] + raw
     end
 
+    def lock_key
+      "cachext:lock:#{digest}"
+    end
+
     def locked?
-      lock_redis.exists digest
+      lock_redis.exists lock_key
     end
 
     def read

--- a/lib/cachext/multi.rb
+++ b/lib/cachext/multi.rb
@@ -106,7 +106,7 @@ module Cachext
 
       def lock_key_from_ids(ids)
         key = Key.new multi.key_base + ids
-        key.digest
+        key.lock_key
       end
 
       def write_cache records

--- a/spec/cachext/client_spec.rb
+++ b/spec/cachext/client_spec.rb
@@ -1,11 +1,11 @@
 require "spec_helper"
 
-FooError = Class.new(StandardError)
-
 describe Cachext, "caching" do
+  FooError = Class.new(StandardError)
+
   let(:cache) { Cachext.config.cache }
 
-  let(:config) { Cachext::Configuration.new }
+  let(:config) { Cachext.config }
   subject { Cachext::Client.new config }
 
   let(:key) { Cachext::Key.new [:test, 1] }

--- a/spec/cachext/multi_spec.rb
+++ b/spec/cachext/multi_spec.rb
@@ -264,7 +264,7 @@ describe Cachext::Multi do
         child = nil
         begin
           child = fork do
-            Cachext.config.cache = ActiveSupport::Cache::MemCacheStore.new
+            Cachext.forked!
             Cachext.multi([:sleeper], [1,2,3], heartbeat_expires: 0.5) { sleep }
           end
           sleep 0.1
@@ -275,6 +275,7 @@ describe Cachext::Multi do
           expect(key).to_not be_locked # but now it should be cleared because no heartbeat
         ensure
           Process.kill('KILL', child) rescue Errno::ESRCH
+          Process.wait
         end
       end
 
@@ -282,7 +283,7 @@ describe Cachext::Multi do
         child = nil
         begin
           child = fork do
-            Cachext.config.cache = ActiveSupport::Cache::MemCacheStore.new
+            Cachext.forked!
             Cachext.multi([:sleeper], [1,2,3], heartbeat_expires: 0.5) { sleep }
           end
           sleep 0.1
@@ -295,6 +296,7 @@ describe Cachext::Multi do
           expect(key).to be_locked # the other process still has it
         ensure
           Process.kill('TERM', child) rescue Errno::ESRCH
+          Process.wait
         end
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,16 +18,12 @@ class DummyErrorLogger
   end
 end
 
-MEMCACHE = ActiveSupport::Cache::MemCacheStore.new
-REDIS = Redis.new
-LOGGER = DummyErrorLogger.new
-
 RSpec.configure do |config|
   config.before do
     Cachext.configure do |c|
-      c.cache = MEMCACHE
-      c.redis = REDIS
-      c.error_logger = LOGGER
+      c.cache = ActiveSupport::Cache::MemCacheStore.new
+      c.redis = Redis.new
+      c.error_logger = DummyErrorLogger.new
     end
     Cachext.flush
   end


### PR DESCRIPTION
Redlock uses redis scripts, and loading scripts through a Redis::Namespace connection causes warnings to be printed.

This PR removes Redis::Namespace.

Quite a bit of other cleanup was done fixing test failures. I think a lot of due to test ordering and fragile tests.