### PR TITLE
Sleep after checking timeout

### DIFF
--- a/lib/cachext/multi.rb
+++ b/lib/cachext/multi.rb
@@ -95,10 +95,10 @@ module Cachext
         start_time = Time.now
 
         until lock_info = lock_manager.lock(lock_key, (heartbeat_expires * 1000).ceil)
-          sleep rand
           if Time.now - start_time > max_lock_wait
             raise Features::Lock::TimeoutWaitingForLock
           end
+          sleep rand
         end
 
         lock_info


### PR DESCRIPTION
Checking for a timeout before the sleep ensures that we get a higher ratio of lock attempts to time taken.